### PR TITLE
Add instructions for HACS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@ This is a custom component for Home Assistant to allow fetching song lyrics from
 
 *NOTE:* this is a work in progress -- expect changes.
 
+
+## Installation
+
+### With HACS
+1. Open HACS Settings and add this repository (https://github.com/robert-alfaro/genius-lyrics) as a Custom Repository (use **Integration** as the category).
+2. The `Genius Lyrics` page should automatically load (or find it in the HACS Store)
+3. Click `Install`
+
+### Manual
+Copy the `genius_lyrics` directory from `custom_components` in this repository, and place inside your Home Assistant installation's `custom_components` directory.
+
+
 ## Setup
 
 1. Sign up for a free account at genius.com and authorize access to the [Genius API](http://genius.com/api-clients) to get your `client_access_token`.
-2. Copy directory `genius_lyrics` from "custom_components" directory in this repository, and place inside your Home Assistant installation's `custom_components` directory.
+2. Install this component
 3. Install markdown card mod [lovelace-markdown-mod](https://github.com/thomasloven/lovelace-markdown-mod)
 4. Add the following to your `configuration.yaml`
 ```

--- a/custom_components/genius_lyrics/manifest.json
+++ b/custom_components/genius_lyrics/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "genius_lyrics",
   "name": "Genius Lyrics",
-  "documentation": "https://homeassistant.io/components/genius_lyrics",
+  "documentation": "https://github.com/robert-alfaro/genius-lyrics",
   "requirements": ["lyricsgenius"],
   "dependencies": [],
   "codeowners": ["@ralfaro"]

--- a/info.md
+++ b/info.md
@@ -1,0 +1,67 @@
+## Setup
+
+1. Create a Genius.com API token:
+	1. Sign up for a free account at genius.com if you don't have one
+	2. Open the [New API Client](https://genius.com/api-clients/new) page and fill in App Name, App Website URL, and Redirect URL (this won't be used).
+	3. Once you've saved the new client, click the button to generate a `Client Access Token` (record this somewhere safe).
+2. Install markdown card mod [lovelace-markdown-mod](https://github.com/thomasloven/lovelace-markdown-mod)
+3. Install this integration
+4. Enable Genius Lyrics in `configuration.yaml` by adding the following:
+
+	```
+	genius_lyrics:
+	```
+
+5. Create a template sensor named `lyrics`:
+
+	```yaml
+	sensors:
+	  - platform: template
+	    sensors:
+	      lyrics:
+	        friendly_name: "Lyrics"
+	        value_template: ""
+	```
+
+6. Create a Markdown card in Lovelace that accesses the attributes of the new `lyrics` sensor:
+
+	```yaml
+	  - type: markdown
+	    content: >
+	      ## [[ sensor.lyrics.attributes.artist ]] - [[ sensor.lyrics.attributes.title ]]
+	      
+	      [[ sensor.lyrics.attributes.lyrics ]]
+	```
+
+7. Create an automation to call service `genius_lyrics.search_lyrics` upon media_player state change, and provide `artist_name` and `song_title`, along with `api_key` and the lyrics sensor `entity_id`.
+
+---
+
+### Example service call JSON
+
+```json
+{
+ "api_key":"3SxSxqZJOtz5fYlkFXv-12E-mgripD0XM7v0L091P3Kz22wT9ReCRNg0qmrYeveG",
+ "artist_name":"Protoje",
+ "song_title":"Mind of a King",
+ "entity_id":"sensor.lyrics"
+}
+```
+
+### Example automation YAML
+
+```yaml
+automation:
+  - alias: "Update Genius Lyrics when Spotify song changes."
+    trigger:
+      platform: template
+      value_template: "{{ states.media_player.spotify.attributes.media_title != states.sensor.genius_lyrics.attributes.title }}"
+    action:
+      - service: genius_lyrics.searchlyrics
+        data:
+          api_key: "3SxSxqZJOtz5fYlkFXv-12E-mgripD0XM7v0L091P3Kz22wT9ReCRNg0qmrYeveG"
+          entity_id: sensor.lyrics
+        data_template:
+          artist_name: "{{ states.media_player.spotify.attributes.media_artist }}"
+          song_title: "{{ states.media_player.spotify.attributes.media_title }}"
+```


### PR DESCRIPTION
First off, thank you so much for this project! I have recently been wanting to pull lyrics into HA, and this project does exactly that.

This PR contains some small documentation improvements:
* Modify `README.md` to include specific instructions for installing with HACS
* Add `info.md` file that HACS shows on the component detail page
* Fix documentation link

This PR could probably "fix" #2 (since `custom_updater` is [deprecated in favor of HACS](https://github.com/custom-components/custom_updater/issues/117)). This repository already works with HACS without this PR - I just added some extra documentation.