### PR TITLE
Change the way the access token is provided, fix issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This is a custom component for Home Assistant to allow fetching song lyrics from
 2. Copy directory `genius_lyrics` from "custom_components" directory in this repository, and place inside your Home Assistant installation's `custom_components` directory.
 3. Install markdown card mod [lovelace-markdown-mod](https://github.com/thomasloven/lovelace-markdown-mod)
 4. Add the following to your `configuration.yaml`
+
 ```
 genius_lyrics:
+  access_token: "your Genius client access token"
 
 sensors:
   - platform: template
@@ -20,7 +22,9 @@ sensors:
         friendly_name: "Lyrics"
         value_template: ""
 ```
+
 5. Create markdown card in lovelace.
+
 ```
   - type: markdown
     content: >
@@ -28,6 +32,7 @@ sensors:
 
       [[ sensor.lyrics.attributes.lyrics ]]
 ```
+
 6. Create an automation to call service `genius_lyrics.search_lyrics` upon media_player state change, providing "Artist", "Title".
 
 ---
@@ -42,7 +47,6 @@ sensors:
 
 ```json
 {
- "api_key":"3SxSxqZJOtz5fYlkFXv-12E-mgripD0XM7v0L091P3Kz22wT9ReCRNg0qmrYeveG",
  "artist_name":"Protoje",
  "song_title":"Mind of a King",
  "entity_id":"sensor.lyrics"

--- a/custom_components/genius_lyrics/__init__.py
+++ b/custom_components/genius_lyrics/__init__.py
@@ -5,7 +5,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_ENTITY_ID, CONF_API_KEY
+from homeassistant.const import CONF_ENTITY_ID, CONF_ACCESS_TOKEN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,23 +15,27 @@ DOMAIN = 'genius_lyrics'
 ATTR_ARTIST_NAME = 'artist_name'
 ATTR_SONG_TITLE = 'song_title'
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ACCESS_TOKEN): cv.string
+    })
+}, extra=vol.ALLOW_EXTRA)
+
 SERVICE_SEARCH_LYRICS = "search_lyrics"
 SERVICE_SEARCH_LYRICS = vol.Schema({
-    vol.Required(CONF_API_KEY): cv.string,
     vol.Required(ATTR_ARTIST_NAME): cv.string,
     vol.Required(ATTR_SONG_TITLE): cv.string,
     vol.Optional(CONF_ENTITY_ID): cv.entity_id,
 })
 
 
-
 def setup(hass, config):
-    """Set up is called when Home Assistant is loading our component."""
+    """setup is called when Home Assistant is loading our component."""
+    genius_access_token = config[DOMAIN][CONF_ACCESS_TOKEN]
 
     def search_lyrics(call):
         """Handle searching for a song's lyrics."""
         data = call.data
-        api_key = data[CONF_API_KEY]
         artist = data[ATTR_ARTIST_NAME]
         song = data[ATTR_SONG_TITLE]
         entity_id = data.get(CONF_ENTITY_ID)
@@ -44,7 +48,7 @@ def setup(hass, config):
 
         # get lyrics
         from lyricsgenius import Genius
-        genius = Genius(CONF_API_KEY)
+        genius = Genius(genius_access_token)
         song = genius.search_song(song, artist, get_full_info=False)
         #_LOGGER.info("Song data: \n{}".format(song.to_dict()))
 

--- a/custom_components/genius_lyrics/__init__.py
+++ b/custom_components/genius_lyrics/__init__.py
@@ -21,13 +21,6 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-SERVICE_SEARCH_LYRICS = "search_lyrics"
-SERVICE_SEARCH_LYRICS = vol.Schema({
-    vol.Required(ATTR_ARTIST_NAME): cv.string,
-    vol.Required(ATTR_SONG_TITLE): cv.string,
-    vol.Optional(CONF_ENTITY_ID): cv.entity_id,
-})
-
 
 def setup(hass, config):
     """setup is called when Home Assistant is loading our component."""

--- a/custom_components/genius_lyrics/manifest.json
+++ b/custom_components/genius_lyrics/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://homeassistant.io/components/genius_lyrics",
   "requirements": ["lyricsgenius"],
   "dependencies": [],
-  "codeowners": ["@ralfaro"]
+  "codeowners": ["@ralfaro", "@airdrummingfool"]
 }

--- a/info.md
+++ b/info.md
@@ -1,0 +1,66 @@
+## Setup
+
+1. Create a Genius.com access token:
+	1. Sign up for a free account at genius.com if you don't have one
+	2. Open the [New API Client](https://genius.com/api-clients/new) page and fill in App Name, App Website URL, and Redirect URL (this won't be used).
+	3. Once you've saved the new client, click the button to generate a `Client Access Token` (record this somewhere safe).
+2. Install markdown card mod [lovelace-markdown-mod](https://github.com/thomasloven/lovelace-markdown-mod)
+3. Install this integration
+4. Enable Genius Lyrics in `configuration.yaml` by adding the following (*substitute your access token from step 1*):
+
+	```yaml
+	genius_lyrics:
+	  access_token: "3SxSxqZJOtz5fYlkFXv-12E-mgripD0XM7v0L091P3Kz22wT9ReCRNg0qmrYeveG"
+	```
+
+5. Create a template sensor named `lyrics`:
+
+	```yaml
+	sensors:
+	  - platform: template
+	    sensors:
+	      lyrics:
+	        friendly_name: "Lyrics"
+	        value_template: ""
+	```
+
+6. Create a Markdown card in Lovelace that accesses the attributes of the new `lyrics` sensor:
+
+	```yaml
+	  - type: markdown
+	    content: >
+	      ## [[ sensor.lyrics.attributes.artist ]] - [[ sensor.lyrics.attributes.title ]]
+	      
+	      [[ sensor.lyrics.attributes.lyrics ]]
+	```
+
+7. Create an automation to call service `genius_lyrics.search_lyrics` upon media_player state change, and provide `artist_name` and `song_title`, along with the lyrics sensor `entity_id`.
+
+---
+
+### Example service call JSON
+
+```json
+{
+ "artist_name":"Protoje",
+ "song_title":"Mind of a King",
+ "entity_id":"sensor.lyrics"
+}
+```
+
+### Example automation YAML
+
+```yaml
+automation:
+  - alias: "Update Genius Lyrics when Spotify song changes."
+    trigger:
+      platform: template
+      value_template: "{{ states.media_player.spotify.attributes.media_title != states.sensor.genius_lyrics.attributes.title }}"
+    action:
+      - service: genius_lyrics.searchlyrics
+        data:
+          entity_id: sensor.lyrics
+        data_template:
+          artist_name: "{{ states.media_player.spotify.attributes.media_artist }}"
+          song_title: "{{ states.media_player.spotify.attributes.media_title }}"
+```


### PR DESCRIPTION
* Make the access token a `configuration.yaml` key, instead of requiring it to be passed on every service call. This allows users to store it in `secrets.yaml`.
* Actually pass Genius token to the Genius library (see line 44)
* Add myself as a contributor (if this is not appropriate, please let me know)

Note that this is intended to be independent of #3, however since I wanted to update the `info.md` file that adds, this PR contains that file in full. Ideally this would be merged after #3.