### PR TITLE
Handle Genius search failure / song not found

### DIFF
--- a/custom_components/genius_lyrics/__init__.py
+++ b/custom_components/genius_lyrics/__init__.py
@@ -33,7 +33,7 @@ def setup(hass, config):
         data = call.data
         api_key = data[CONF_API_KEY]
         artist = data[ATTR_ARTIST_NAME]
-        song = data[ATTR_SONG_TITLE]
+        title = data[ATTR_SONG_TITLE]
         entity_id = data.get(CONF_ENTITY_ID)
         state = data.get("state")
         old_state = hass.states.get(entity_id)
@@ -45,12 +45,20 @@ def setup(hass, config):
         # get lyrics
         from lyricsgenius import Genius
         genius = Genius(CONF_API_KEY)
-        song = genius.search_song(song, artist, get_full_info=False)
-        #_LOGGER.info("Song data: \n{}".format(song.to_dict()))
+        #_LOGGER.debug("Searching for lyrics with artist '{}' and title '{}'".format(artist, title))
+        song = genius.search_song(title, artist, get_full_info=False)
 
-        attrs = song.to_dict()
-        attrs['artist'] = artist.title()  # title case until we have a preformatted name
-        attrs['title'] = attrs['title']
+        if song is None:
+            #_LOGGER.debug("Song not found.")
+            attrs = {
+                'artist': artist.title(),
+                'title' : title,
+                'lyrics': None
+            }
+        else:
+            #_LOGGER.debug("Song data: \n{}".format(song.to_dict()))
+            attrs = song.to_dict()
+            attrs['artist'] = artist.title()  # title case until we have a preformatted name
 
         if entity_id is not None:
             hass.states.set(entity_id, state, attrs)


### PR DESCRIPTION
If the song search fails (e.g. if Genius doesn't have the song in its database), the LyricsGenius library returns `None`. Before this PR, a `None` return value from the library would cause an error - now it sets the artist and song title appropriately, but sets the lyrics to `None` to indicate they were not found successfully. There is probably a more elegant way to indicate an error, but this is what I came up with short-term 🤷‍♂ 

Sidenote: I did not anticipate submitting PRs back-to-back(-to-back). In order to keep them clean and focused, I've based each on your master branch (each PR does not depend on any other PR). Unfortunately this means they might be a bit annoying to merge (there will be conflicts). If you would prefer one large PR with all of my changes thus far, I would be happy to provide that instead.