### PR TITLE
Fix component in 2022.4.x

### DIFF
--- a/custom_components/genius_lyrics/sensor.py
+++ b/custom_components/genius_lyrics/sensor.py
@@ -101,7 +101,7 @@ class GeniusLyricsSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         state_attrs = {
             ATTR_MEDIA_ARTIST: self._genius.artist,
             ATTR_MEDIA_TITLE: self._genius.title,


### PR DESCRIPTION
`device_state_attributes` has been deprecated since 2021.4.x. 

With the release of 2022.4.x, support was removed entirely.

Thankfully, it's just a quick one word change which restores functionality!

Fixes #17 and #19.