### PR TITLE
Add support for STATE_BUFFERING introduced in 2022.5.x

### DIFF
--- a/custom_components/genius_lyrics/sensor.py
+++ b/custom_components/genius_lyrics/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_PLAYING,
     STATE_PAUSED,
+    STATE_BUFFERING,
 )
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,
@@ -123,7 +124,7 @@ class GeniusLyricsSensor(Entity):
         if entity_id != self._media_player_id:
             return
 
-        if new_state.state not in [STATE_PLAYING, STATE_PAUSED]:
+        if new_state.state not in [STATE_PLAYING, STATE_PAUSED, STATE_BUFFERING]:
             self._genius.reset()
             self._state = STATE_OFF
             self.async_schedule_update_ha_state(True)


### PR DESCRIPTION
`STATE_BUFFERING` was added to home assistant in 2022.5.x (https://github.com/home-assistant/core/pull/70802).

If you don't have the best internet this can cause this entity to flicker between on and off, never allowing enough time to get the lyrics. Therefore we shouldn't turn the entity off if the media player is buffering.