### PR TITLE
Remove missing artist/title error log

### DIFF
--- a/custom_components/genius_lyrics/sensor.py
+++ b/custom_components/genius_lyrics/sensor.py
@@ -203,7 +203,7 @@ class GeniusLyrics:
             self.__title = title
 
         if self.__artist is None or self.__title is None:
-            _LOGGER.error("Missing artist and/or title")
+            #_LOGGER.error("Missing artist and/or title")
             return
 
         _LOGGER.info(f"Search lyrics for artist='{self.__artist}' and title='{self.__title}'")


### PR DESCRIPTION
Because this error triggers a lot when Spotify isn't playing anything, the error doesn't really provide any value and just creates a lot of noise within the Home Assistant logs.

Happy to go for any alternative method to quiet it; commenting out the error is a quick fix though 😄 

![Screenshot of the Home Assistant error showing 1308 occurrences in 5 days](https://user-images.githubusercontent.com/6129428/175023223-6786559b-842b-4824-b6ad-0dacb4624b8c.png)