### PR TITLE
Set 'missing artist and/or title' error to debug

### DIFF
--- a/custom_components/genius_lyrics/sensor.py
+++ b/custom_components/genius_lyrics/sensor.py
@@ -203,7 +203,7 @@ class GeniusLyrics:
             self.__title = title
 
         if self.__artist is None or self.__title is None:
-            _LOGGER.error("Missing artist and/or title")
+            _LOGGER.debug("Missing artist and/or title")
             return
 
         _LOGGER.info(f"Search lyrics for artist='{self.__artist}' and title='{self.__title}'")


### PR DESCRIPTION
Useful error when you're trying to debug... less useful when you're just not listening to music and therefore there is no artist or title 😁 

This changes it to `_logger.debug`.