### PR TITLE
Improve the lyrics search results by removing anything after the ' - ' in the song title

### DIFF
--- a/custom_components/genius_lyrics/helpers.py
+++ b/custom_components/genius_lyrics/helpers.py
@@ -3,6 +3,7 @@
 import logging
 from lyricsgenius.song import Song
 from re import compile as re_compile
+from re import sub as re_sub
 
 from homeassistant.core import HomeAssistant
 from homeassistant.const import ATTR_RESTORED
@@ -26,6 +27,14 @@ def cleanup_lyrics(song: Song) -> str:
 
     # Pattern3: match ending with Pyong Count
     lyrics = lyrics.rstrip(str(song.pyongs_count))
+    
+    # Pattern4: remove 'You might also like'
+    lyrics = lyrics.replace("You might also like[","[")
+    
+    # Pattern5: remove live ticket advertising
+    deletetxt = "See " + song.artist + " LiveGet tickets as low as "
+    lyrics = lyrics.replace(deletetxt, "")
+    lyrics = re_sub("\$[0-9]*\[","[", lyrics)
 
     return lyrics
 

--- a/custom_components/genius_lyrics/sensor.py
+++ b/custom_components/genius_lyrics/sensor.py
@@ -103,6 +103,10 @@ class GeniusLyricsSensor(SensorEntity):
             _LOGGER.error("Cannot fetch lyrics without artist and title")
             return
 
+        # remove hyphen from title
+        if " - " in self._media_title:
+           self._media_title = self._media_title.split(' - ',1)[0] # remove anything after the ' - '
+           
         _LOGGER.info(
             "Searching lyrics for artist='%s' and title='%s'",
             self._media_artist,


### PR DESCRIPTION
I've had much better success in getting lyrics returned when the words after ' - ' are removed from the song title before the search.  Many songs have ' - Remastered <year>', ' - Radio Edit', ' - Single' and the like after them that clearly do not appear in the song's actual title.